### PR TITLE
New link to d3 js file that supports HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@ layout: index
 ---
 
 
-<script src="https://d3js.org/d3.v3.min.js" charset="utf-8"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.6/d3.min.js" charset="utf-8"></script>
 <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
 <link href='https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300' rel='stylesheet' type='text/css'>
 


### PR DESCRIPTION
Turns out d3js.org doesn't support HTTPS, but have kindly linked the file which is also on a CDN, which is nice.
